### PR TITLE
feat: Add user profile feature

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "js-cookie": "^3.0.5",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-scripts": "5.0.1",
@@ -11037,6 +11038,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "js-cookie": "^3.0.5",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,36 +1,65 @@
-import React from 'react';
-import './Layout.css'; // Import the new layout CSS
+import React, { useState, useEffect } from 'react';
+import Cookies from 'js-cookie';
+import './Layout.css';
 import Chat from './components/Chat';
 import MainContent from './components/MainContent';
 import MenuBar from './components/MenuBar';
 import DiceShortcuts from './components/DiceShortcuts';
 import VideoChat from './VideoChat';
+import UserSetupModal from './components/UserSetupModal';
 
 function App() {
+  const [userProfile, setUserProfile] = useState(null);
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    const savedProfile = Cookies.get('userProfile');
+    if (savedProfile) {
+      setUserProfile(JSON.parse(savedProfile));
+    } else {
+      setShowModal(true);
+    }
+  }, []);
+
+  const handleSaveProfile = (profile) => {
+    Cookies.set('userProfile', JSON.stringify(profile), { expires: 365 });
+    setUserProfile(profile);
+    setShowModal(false);
+  };
+
+  const handleResetProfile = () => {
+    Cookies.remove('userProfile');
+    setUserProfile(null);
+    setShowModal(true);
+  };
+
   return (
-    <div className="app-layout">
-      <div className="left-column">
-        <div className="chat-area">
-          <Chat />
+    <>
+      {showModal && <UserSetupModal onSave={handleSaveProfile} />}
+      <div className="app-layout">
+        <div className="left-column">
+          <div className="chat-area">
+            <Chat userProfile={userProfile} />
+          </div>
+          <div className="dice-shortcuts-area">
+            <DiceShortcuts />
+          </div>
         </div>
-        <div className="dice-shortcuts-area">
-          <DiceShortcuts />
+        <div className="center-column">
+          <div className="main-content-area">
+            <MainContent />
+          </div>
+          <div className="menu-bar-area">
+            <MenuBar onReset={handleResetProfile} />
+          </div>
+        </div>
+        <div className="right-column">
+          <div className="video-chat-area">
+            <VideoChat />
+          </div>
         </div>
       </div>
-      <div className="center-column">
-        <div className="main-content-area">
-          <MainContent />
-        </div>
-        <div className="menu-bar-area">
-          <MenuBar />
-        </div>
-      </div>
-      <div className="right-column">
-        <div className="video-chat-area">
-          <VideoChat />
-        </div>
-      </div>
-    </div>
+    </>
   );
 }
 

--- a/client/src/components/Chat.js
+++ b/client/src/components/Chat.js
@@ -1,9 +1,16 @@
 import React from 'react';
 
-const Chat = () => {
+const Chat = ({ userProfile }) => {
     return (
         <>
-            <h2>Chat</h2>
+            {userProfile ? (
+                <div style={{ marginBottom: '10px', borderBottom: '1px solid #ccc', paddingBottom: '10px' }}>
+                    <span style={{ fontSize: '2rem', marginRight: '10px', verticalAlign: 'middle' }}>{userProfile.icon}</span>
+                    <strong style={{ verticalAlign: 'middle' }}>{userProfile.name}</strong>
+                </div>
+            ) : (
+                <h2>Chat</h2>
+            )}
             {/* Chat messages will go here */}
         </>
     );

--- a/client/src/components/MenuBar.js
+++ b/client/src/components/MenuBar.js
@@ -1,12 +1,13 @@
 import React from 'react';
 
-const MenuBar = () => {
+const MenuBar = ({ onReset }) => {
     return (
         <>
             {/* Menu items will go here */}
             <button>Character Sheets</button>
             <button>Scene</button>
             <button>Whiteboard</button>
+            <button onClick={onReset} style={{ marginLeft: 'auto' }}>Reset Profile</button>
         </>
     );
 };

--- a/client/src/components/UserSetupModal.js
+++ b/client/src/components/UserSetupModal.js
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+
+const icons = ['🧙', '🧝', '🧛', '🧟', '🧞', '🧑‍🚀'];
+
+const modalStyles = {
+    position: 'fixed',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    backgroundColor: 'white',
+    padding: '20px',
+    borderRadius: '8px',
+    zIndex: 1000,
+    boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)'
+};
+
+const backdropStyles = {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    zIndex: 999
+};
+
+const UserSetupModal = ({ onSave }) => {
+    const [name, setName] = useState('');
+    const [selectedIcon, setSelectedIcon] = useState(icons[0]);
+
+    const handleSave = () => {
+        if (name.trim() === '') {
+            alert('Please enter a name.');
+            return;
+        }
+        onSave({ name, icon: selectedIcon });
+    };
+
+    return (
+        <>
+            <div style={backdropStyles}></div>
+            <div style={modalStyles}>
+                <h2>Create Your Character</h2>
+                <div>
+                    <label>
+                        Name:
+                        <input
+                            type="text"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            style={{ marginLeft: '10px', padding: '5px' }}
+                        />
+                    </label>
+                </div>
+                <div style={{ marginTop: '10px' }}>
+                    <label>
+                        Icon:
+                        <div style={{ display: 'flex', gap: '10px', marginTop: '5px' }}>
+                            {icons.map(icon => (
+                                <span
+                                    key={icon}
+                                    onClick={() => setSelectedIcon(icon)}
+                                    style={{
+                                        cursor: 'pointer',
+                                        fontSize: '2rem',
+                                        border: selectedIcon === icon ? '2px solid blue' : '2px solid transparent',
+                                        borderRadius: '50%',
+                                        padding: '5px'
+                                    }}
+                                >
+                                    {icon}
+                                </span>
+                            ))}
+                        </div>
+                    </label>
+                </div>
+                <button
+                    onClick={handleSave}
+                    style={{ marginTop: '20px', padding: '10px 20px', cursor: 'pointer' }}
+                >
+                    Save
+                </button>
+            </div>
+        </>
+    );
+};
+
+export default UserSetupModal;


### PR DESCRIPTION
This commit introduces a user profile feature that allows users to set a character name and choose an icon.

Key changes include:
- A modal prompts new users to create their profile upon their first visit.
- The user's profile (name and icon) is saved in a cookie to persist across sessions.
- A 'Reset Profile' button has been added to the menu bar, allowing users to clear their profile and set a new one.
- The user's selected name and icon are displayed in the chat area.
- The `js-cookie` library has been added to manage cookies.