### PR TITLE
feat: Implement server-side storage for chat history

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const http = require("http");
+const fs = require("fs");
 const app = express();
 const server = http.createServer(app);
 const socket = require("socket.io");
@@ -11,22 +12,73 @@ const io = socket(server, {
 });
 
 const users = {};
+const chatHistoryPath = 'chat_history.json';
+
+// --- Chat History Management ---
+
+// Ensure chat history file exists on startup
+if (!fs.existsSync(chatHistoryPath)) {
+    fs.writeFileSync(chatHistoryPath, JSON.stringify([]));
+}
+
+const readChatHistory = () => {
+    try {
+        const data = fs.readFileSync(chatHistoryPath, 'utf8');
+        return JSON.parse(data);
+    } catch (error) {
+        console.error("Error reading chat history:", error);
+        return [];
+    }
+};
+
+const writeChatHistory = (history) => {
+    try {
+        let historyToSave = [...history];
+        let jsonHistory = JSON.stringify(historyToSave, null, 2);
+        const MAX_SIZE_BYTES = 5 * 1024 * 1024;
+
+        while (Buffer.from(jsonHistory, 'utf8').length > MAX_SIZE_BYTES && historyToSave.length > 0) {
+            historyToSave.shift(); // Remove the oldest message
+            jsonHistory = JSON.stringify(historyToSave, null, 2);
+        }
+
+        fs.writeFileSync(chatHistoryPath, jsonHistory);
+        return historyToSave; // Return the potentially trimmed array
+    } catch (error) {
+        console.error("Error writing chat history:", error);
+        return history; // On error, return the original untrimmed history
+    }
+};
+
+// --- Socket.IO Connection Handling ---
 
 io.on('connection', socket => {
-    //generate a random id for the user and add it to the list of users
+    // --- User & WebRTC Connection Logic ---
     if (!users[socket.id]) {
         users[socket.id] = socket.id;
     }
-    //send the id to the user
     socket.emit("yourID", socket.id);
-    //send all the users to the new user
     io.sockets.emit("allUsers", Object.keys(users));
     socket.on('disconnect', () => {
-        //remove user from the list of users
         delete users[socket.id];
-    })
+        io.sockets.emit("allUsers", Object.keys(users)); // Notify clients of user disconnection
+    });
 
-    //a user is trying to call another user
+    // --- Chat Logic ---
+    // Send the current chat history to the connecting client
+    socket.emit('chat history', readChatHistory());
+
+    // Listen for a new message from a client
+    socket.on('new message', (message) => {
+        const history = readChatHistory();
+        history.push(message);
+        writeChatHistory(history); // Save the updated history
+
+        // Broadcast the new message to all clients
+        io.emit('new message', message);
+    });
+
+    // --- WebRTC Signaling Logic ---
     socket.on("callUser", (data) => {
         //send the signal to the other user
         io.to(data.userToCall).emit('hey', {signal: data.signalData, from: data.from});


### PR DESCRIPTION
This commit refactors the chat system to use a server-authoritative state, with chat history persisted on the server instead of in the client's `localStorage`.

Key changes:
- The server now stores chat history in a `chat_history.json` file.
- Logic has been added to the server to read, write, and trim the history file to stay within a 5MB limit.
- On connection, the server sends the full chat history to the client.
- New messages are sent to the server, saved, and then broadcast to all connected clients.
- The client-side application has been refactored to remove all `localStorage` logic for chat and now relies on Socket.IO events for all chat state management.
- The application now uses a single, shared Socket.IO connection, improving efficiency.