### PR TITLE
fix: Resolve bug in fog of war eraser

### DIFF
--- a/whiteboard.js
+++ b/whiteboard.js
@@ -117,7 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
             // Turning fog on - behavior depends on user role
             if (username === 'MJ') {
                 // MJ gets the advanced, erasable fog
-                fogClipGroup = new fabric.Group([], { inverted: true });
+                fogClipGroup = new fabric.Group([], { inverted: true, absolutePositioned: true });
                 fogRect = new fabric.Rect({
                     width: canvas.width, height: canvas.height,
                     fill: 'rgba(0,0,0,0.85)',


### PR DESCRIPTION
This commit fixes a bug where using the eraser tool as the 'MJ' would cause the entire fog of war layer to disappear, instead of just the erased area.

The issue was resolved by adding the `absolutePositioned: true` property to the `fabric.Group` used as the inverted `clipPath` for the fog layer. This ensures that the clipping paths are calculated correctly relative to the canvas, preventing the entire layer from being clipped.