### PR TITLE
fix: Correct script path and add placeholder pages

### DIFF
--- a/pages/fiches.html
+++ b/pages/fiches.html
@@ -1,0 +1,4 @@
+<div style="padding: 20px;">
+    <h2>Fiches de Personnages</h2>
+    <p>Cette section n'est pas encore implémentée.</p>
+</div>

--- a/pages/scene.html
+++ b/pages/scene.html
@@ -1,0 +1,4 @@
+<div style="padding: 20px;">
+    <h2>Scène</h2>
+    <p>Cette section n'est pas encore implémentée.</p>
+</div>

--- a/pages/tableau.html
+++ b/pages/tableau.html
@@ -16,4 +16,4 @@
         <canvas id="drawingCanvas"></canvas>
     </div>
 </div>
-<script src="tableau.js"></script>
+<script src="pages/tableau.js"></script>


### PR DESCRIPTION
This commit provides the definitive fix for the whiteboard feature by correcting a critical file path error that prevented its JavaScript from loading.

- The `src` attribute in the `<script>` tag in `pages/tableau.html` has been corrected to point to `pages/tableau.js`. This resolves the bug where the whiteboard buttons were non-functional.
- Empty placeholder files have been created for `pages/fiches.html` and `pages/scene.html` to prevent 404 errors when clicking other navigation buttons.