### PR TITLE
fix: Add missing Fabric.js library to whiteboard view

### DIFF
--- a/pages/tableau.html
+++ b/pages/tableau.html
@@ -1,3 +1,4 @@
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.3.1/fabric.min.js"></script>
 <div id="main-container" style="display: flex; flex-direction: column; height: 100%;">
     <div id="toolbar" style="padding: 10px; background-color: #f0f0f0; border-bottom: 1px solid #ccc; flex-shrink: 0;">
         <button id="addBackground">Fond d'écran</button>


### PR DESCRIPTION
This commit fixes a critical bug that prevented the whiteboard from loading. The Fabric.js library was not being included in the dynamically loaded `tableau.html` view, which resulted in a "fabric is not defined" error and halted all script execution.

A script tag pointing to the Fabric.js CDN has been added to `pages/tableau.html`. This ensures the library is loaded before the whiteboard's own script is executed, allowing it to initialize correctly. This should resolve all outstanding issues with non-functional buttons and broken chat updates.