### PR TITLE
feat: Add Google Sheets viewer functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,11 +31,19 @@
                 <!-- Le contenu principal (whiteboard, etc.) ira ici -->
                 <p>Zone d'affichage principale.</p>
             </div>
-            <nav class="main-menu">
-                <a href="#carte" class="menu-item">Carte</a>
-                <a href="#pj" class="menu-item">PJ</a>
-                <a href="#prez" class="menu-item">Prez</a>
-            </nav>
+            <div class="menu-container">
+                <nav class="main-menu">
+                    <a href="#carte" class="menu-item">Carte</a>
+                    <a href="#pj" class="menu-item">PJ</a>
+                    <a href="#prez" class="menu-item">Prez</a>
+                </nav>
+                <div class="sheets-controls">
+                    <select id="sheet-select">
+                        <option value="">Choisir une fiche</option>
+                    </select>
+                    <button id="add-sheet-btn">+</button>
+                </div>
+            </div>
         </main>
         <aside class="panel right-panel">
             <div class="panel-header">
@@ -56,5 +64,6 @@
     <button id="toggle-video-panel-btn" title="Cacher le panneau de vidéo">»</button>
 
     <script src="script.js" defer></script>
+    <script src="sheets.js" defer></script>
 </body>
 </html>

--- a/sheets.js
+++ b/sheets.js
@@ -1,0 +1,104 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const mainDisplay = document.querySelector('.main-display');
+    const sheetSelect = document.getElementById('sheet-select');
+    const addSheetBtn = document.getElementById('add-sheet-btn');
+
+    const storageKey = 'googleSheets';
+    let sheets = [];
+    const originalMainContent = mainDisplay.innerHTML;
+
+    // --- Data Management ---
+
+    function loadSheets() {
+        const storedSheets = localStorage.getItem(storageKey);
+        if (storedSheets) {
+            sheets = JSON.parse(storedSheets);
+            populateDropdown();
+        }
+    }
+
+    function saveSheets() {
+        localStorage.setItem(storageKey, JSON.stringify(sheets));
+    }
+
+    function formatSheetUrl(url) {
+        // Attempt to convert a standard Google Sheet URL to an embeddable one.
+        // This requires the sheet to be "Published to the web".
+        // Example: /edit?usp=sharing -> /pubhtml
+        // Example: /edit -> /pubhtml
+        try {
+            const urlObject = new URL(url);
+            if (urlObject.hostname.includes('docs.google.com') && urlObject.pathname.includes('/spreadsheets/d/')) {
+                return url.replace(/\/edit.*$/, '/pubhtml?widget=true&headers=false');
+            }
+        } catch (e) {
+            // Ignore invalid URLs
+        }
+        // Return the original URL if it's not a standard Google Sheet link
+        return url;
+    }
+
+    // --- UI Updates ---
+
+    function populateDropdown() {
+        // Clear existing options, keeping the placeholder
+        while (sheetSelect.options.length > 1) {
+            sheetSelect.remove(1);
+        }
+
+        sheets.forEach(sheet => {
+            const option = document.createElement('option');
+            option.value = sheet.url;
+            option.textContent = sheet.name;
+            sheetSelect.appendChild(option);
+        });
+    }
+
+    function displaySheet(url) {
+        mainDisplay.innerHTML = ''; // Clear the display area
+
+        if (url) {
+            const iframe = document.createElement('iframe');
+            iframe.src = url;
+            iframe.style.width = '100%';
+            iframe.style.height = '100%';
+            iframe.style.border = 'none';
+            mainDisplay.appendChild(iframe);
+        } else {
+            // Restore the original content if no sheet is selected
+            mainDisplay.innerHTML = originalMainContent;
+        }
+    }
+
+    // --- Event Handlers ---
+
+    function handleAddSheetClick() {
+        const name = prompt('Entrez le nom de la fiche :');
+        if (!name) return;
+
+        const url = prompt('Entrez le lien web de la fiche Google Sheet :');
+        if (!url) return;
+
+        const formattedUrl = formatSheetUrl(url);
+
+        sheets.push({ name, url: formattedUrl });
+        saveSheets();
+        populateDropdown();
+
+        // Automatically select and display the new sheet
+        sheetSelect.value = formattedUrl;
+        displaySheet(formattedUrl);
+    }
+
+    function handleSheetSelectChange() {
+        const selectedUrl = sheetSelect.value;
+        displaySheet(selectedUrl);
+    }
+
+    // --- Initialization ---
+
+    addSheetBtn.addEventListener('click', handleAddSheetClick);
+    sheetSelect.addEventListener('change', handleSheetSelectChange);
+
+    loadSheets();
+});

--- a/style.css
+++ b/style.css
@@ -101,19 +101,66 @@ body, html {
 .main-display {
     width: 100%;
     text-align: center;
+    flex-grow: 1; /* Allow this area to grow and fill space */
+    display: flex; /* Use flex to make child iframe fill it */
+    justify-content: center;
+    align-items: center;
 }
 
 /* Menu de navigation */
-.main-menu {
+.menu-container {
     display: flex;
     justify-content: center;
+    align-items: center;
     gap: 20px;
     width: 80%;
-    padding: 8px 0;
+    padding: 8px;
     background-color: #2c2c2c;
     border-radius: 10px;
     border: 1px solid #3a3a3a;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+.main-menu {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+}
+
+.sheets-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+#sheet-select {
+    background-color: #3e3e3e;
+    color: #e0e0e0;
+    border: 1px solid #555;
+    border-radius: 6px;
+    padding: 5px 10px;
+    font-size: 14px;
+}
+
+#sheet-select:hover {
+    background-color: #4a4a4a;
+}
+
+#add-sheet-btn {
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    width: 28px;
+    height: 28px;
+    font-size: 20px;
+    line-height: 28px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+#add-sheet-btn:hover {
+    background-color: #45a049;
 }
 
 .menu-item {


### PR DESCRIPTION
This feature allows users to display Google Sheets in the main content area of the application.

Key features include:
- A dropdown menu to select from a list of saved Google Sheets.
- A "+" button to add a new sheet by providing a name and a URL.
- Sheet data is persisted in the browser's localStorage.
- The JavaScript logic is encapsulated in a new `sheets.js` file to keep the codebase organized.
- The new UI elements are styled to be discreet and consistent with the existing application theme.