### PR TITLE
feat: Implement tabbed navigation and refactor Sheets viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,22 +28,29 @@
         </aside>
         <main class="main-content">
             <div class="main-display">
-                <!-- Le contenu principal (whiteboard, etc.) ira ici -->
-                <p>Zone d'affichage principale.</p>
-            </div>
-            <div class="menu-container">
-                <nav class="main-menu">
-                    <a href="#carte" class="menu-item">Carte</a>
-                    <a href="#pj" class="menu-item">PJ</a>
-                    <a href="#prez" class="menu-item">Prez</a>
-                </nav>
-                <div class="sheets-controls">
-                    <select id="sheet-select">
-                        <option value="">Choisir une fiche</option>
-                    </select>
-                    <button id="add-sheet-btn">+</button>
+                <div id="carte-content" class="tab-content">
+                    <p>Contenu de la section Carte.</p>
+                </div>
+                <div id="pj-content" class="tab-content">
+                    <div class="sheets-controls">
+                        <select id="sheet-select">
+                            <option value="">Choisir une fiche</option>
+                        </select>
+                        <button id="add-sheet-btn">+</button>
+                    </div>
+                    <div id="sheet-display-area">
+                        <!-- L'iframe de la Google Sheet ira ici -->
+                    </div>
+                </div>
+                <div id="prez-content" class="tab-content">
+                    <p>Contenu de la section Prez.</p>
                 </div>
             </div>
+            <nav class="main-menu">
+                <a href="#carte" class="menu-item" data-target="carte-content">Carte</a>
+                <a href="#pj" class="menu-item" data-target="pj-content">PJ</a>
+                <a href="#prez" class="menu-item" data-target="prez-content">Prez</a>
+            </nav>
         </main>
         <aside class="panel right-panel">
             <div class="panel-header">
@@ -63,6 +70,7 @@
     <button id="toggle-chat-btn" title="Cacher le panneau de chat">«</button>
     <button id="toggle-video-panel-btn" title="Cacher le panneau de vidéo">»</button>
 
+    <script src="navigation.js" defer></script>
     <script src="script.js" defer></script>
     <script src="sheets.js" defer></script>
 </body>

--- a/navigation.js
+++ b/navigation.js
@@ -1,0 +1,60 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const menuItems = document.querySelectorAll('.main-menu .menu-item');
+    const tabContents = document.querySelectorAll('.tab-content');
+
+    function showTab(targetId) {
+        // Hide all tab contents
+        tabContents.forEach(tab => {
+            tab.style.display = 'none';
+        });
+
+        // Remove active class from all menu items
+        menuItems.forEach(item => {
+            item.classList.remove('active');
+        });
+
+        // Show the target tab content
+        const targetTab = document.getElementById(targetId);
+        if (targetTab) {
+            targetTab.style.display = 'flex'; // Use flex to match potential inner layout needs
+        }
+
+        // Add active class to the clicked menu item
+        const activeMenuItem = document.querySelector(`.menu-item[data-target="${targetId}"]`);
+        if (activeMenuItem) {
+            activeMenuItem.classList.add('active');
+        }
+    }
+
+    // Add click event listeners to menu items
+    menuItems.forEach(item => {
+        item.addEventListener('click', (event) => {
+            event.preventDefault();
+            const targetId = item.getAttribute('data-target');
+            // Update URL hash without jumping
+            history.pushState(null, null, `#${targetId.replace('-content', '')}`);
+            showTab(targetId);
+        });
+    });
+
+    // Initial tab display logic
+    function initialTabDisplay() {
+        const hash = window.location.hash.substring(1); // e.g., "pj"
+        let initialTargetId = 'carte-content'; // Default tab
+
+        if (hash) {
+            const potentialTargetId = `${hash}-content`;
+            if (document.getElementById(potentialTargetId)) {
+                initialTargetId = potentialTargetId;
+            }
+        }
+
+        showTab(initialTargetId);
+    }
+
+    // Handle back/forward browser navigation
+    window.addEventListener('popstate', initialTabDisplay);
+
+    // Show the initial tab
+    initialTabDisplay();
+});

--- a/sheets.js
+++ b/sheets.js
@@ -1,11 +1,21 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const mainDisplay = document.querySelector('.main-display');
+    // Only operate within the PJ tab content
+    const pjContent = document.getElementById('pj-content');
+    if (!pjContent) return; // Exit if not on a page with the PJ tab
+
+    const sheetDisplayArea = document.getElementById('sheet-display-area');
     const sheetSelect = document.getElementById('sheet-select');
     const addSheetBtn = document.getElementById('add-sheet-btn');
 
+    // Ensure all required elements are present
+    if (!sheetDisplayArea || !sheetSelect || !addSheetBtn) {
+        console.warn('Sheet components not found. The script will not run.');
+        return;
+    }
+
     const storageKey = 'googleSheets';
     let sheets = [];
-    const originalMainContent = mainDisplay.innerHTML;
+    const originalMainContent = sheetDisplayArea.innerHTML;
 
     // --- Data Management ---
 
@@ -55,7 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function displaySheet(url) {
-        mainDisplay.innerHTML = ''; // Clear the display area
+        sheetDisplayArea.innerHTML = ''; // Clear the display area
 
         if (url) {
             const iframe = document.createElement('iframe');
@@ -63,10 +73,10 @@ document.addEventListener('DOMContentLoaded', () => {
             iframe.style.width = '100%';
             iframe.style.height = '100%';
             iframe.style.border = 'none';
-            mainDisplay.appendChild(iframe);
+            sheetDisplayArea.appendChild(iframe);
         } else {
             // Restore the original content if no sheet is selected
-            mainDisplay.innerHTML = originalMainContent;
+            sheetDisplayArea.innerHTML = originalMainContent;
         }
     }
 

--- a/style.css
+++ b/style.css
@@ -100,37 +100,63 @@ body, html {
 
 .main-display {
     width: 100%;
-    text-align: center;
     flex-grow: 1; /* Allow this area to grow and fill space */
     display: flex; /* Use flex to make child iframe fill it */
-    justify-content: center;
-    align-items: center;
+}
+
+/* Tabbed Content */
+.tab-content {
+    width: 100%;
+    height: 100%;
+    display: none; /* Hidden by default */
+    flex-direction: column;
+    gap: 15px;
+}
+
+#pj-content {
+    /* This is a flex container for its children */
+}
+
+#sheet-display-area {
+    flex-grow: 1; /* The iframe container should take all available space */
+    display: flex;
 }
 
 /* Menu de navigation */
-.menu-container {
+.main-menu {
     display: flex;
     justify-content: center;
-    align-items: center;
     gap: 20px;
     width: 80%;
-    padding: 8px;
+    padding: 8px 0;
     background-color: #2c2c2c;
     border-radius: 10px;
     border: 1px solid #3a3a3a;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
 }
 
-.main-menu {
-    display: flex;
-    justify-content: center;
-    gap: 20px;
+.menu-item {
+    color: #e0e0e0;
+    text-decoration: none;
+    font-size: 15px;
+    padding: 5px 15px;
+    border: none;
+    border-radius: 6px;
+    transition: background-color 0.2s, color 0.2s;
 }
 
+.menu-item:hover, .menu-item.active {
+    background-color: #4a4a4a;
+    color: #ffffff;
+}
+
+/* Controls within the PJ Tab */
 .sheets-controls {
     display: flex;
     align-items: center;
     gap: 8px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #3a3a3a;
 }
 
 #sheet-select {
@@ -161,21 +187,6 @@ body, html {
 
 #add-sheet-btn:hover {
     background-color: #45a049;
-}
-
-.menu-item {
-    color: #e0e0e0;
-    text-decoration: none;
-    font-size: 15px;
-    padding: 5px 15px;
-    border: none;
-    border-radius: 6px;
-    transition: background-color 0.2s, color 0.2s;
-}
-
-.menu-item:hover {
-    background-color: #4a4a4a;
-    color: #ffffff;
 }
 
 /* --- Styles pour le panneau de Chat --- */


### PR DESCRIPTION
This commit introduces a tabbed navigation system in the main content area and refactors the Google Sheets viewer to be one of the tabs.

Key changes:
- The main navigation ("Carte", "PJ", "Prez") now acts as a tab control for the central display area.
- The Google Sheets functionality is now located within the "PJ" tab.
- The sheet selection controls have been moved from the bottom menu bar to the top of the "PJ" content panel.
- A new `navigation.js` file has been created to handle all tab-switching logic, including support for deep-linking via URL hashes (e.g., #pj).
- `sheets.js` has been updated to work within the new DOM structure.
- `style.css` has been updated to support the new layout, including styles for active tabs and the repositioned controls.