### PR TITLE
fix: Reposition image controls to the top of the tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,11 +29,6 @@
         <main class="main-content">
             <div class="main-display">
                 <div id="carte-content" class="tab-content">
-                    <!-- Zone d'affichage de l'image, visible par tous -->
-                    <div id="image-display-area">
-                        <p>Aucune image sélectionnée.</p>
-                    </div>
-
                     <!-- Contrôles pour le MJ, cachés par défaut -->
                     <div class="image-controls hidden">
                         <select id="image-select">
@@ -41,6 +36,11 @@
                         </select>
                         <button id="add-image-btn" class="control-btn btn-add" title="Ajouter une image">+</button>
                         <button id="delete-image-btn" class="control-btn btn-delete" title="Supprimer l'image">-</button>
+                    </div>
+
+                    <!-- Zone d'affichage de l'image, visible par tous -->
+                    <div id="image-display-area">
+                        <p>Aucune image sélectionnée.</p>
                     </div>
                 </div>
                 <div id="pj-content" class="tab-content">


### PR DESCRIPTION
This commit addresses a final layout inconsistency pointed out by the user.

The image management controls on the 'Carte' tab were appearing at the bottom of the content area, while the equivalent controls on the 'PJ' tab were at the top.

By reordering the divs within `index.html`, the image controls are now correctly positioned at the top of the 'Carte' tab, making the layout consistent across all feature tabs.