### PR TITLE
fix: Correct Excalidraw initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,9 +83,9 @@
     <button id="toggle-chat-btn" title="Cacher le panneau de chat">«</button>
     <button id="toggle-video-panel-btn" title="Cacher le panneau de vidéo">»</button>
 
-    <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
-    <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
-    <script src="https://unpkg.com/@excalidraw/excalidraw@0.17.6/dist/excalidraw.production.min.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/@excalidraw/excalidraw/dist/excalidraw.production.min.js"></script>
 
     <script src="navigation.js" defer></script>
     <script src="script.js" defer></script>

--- a/whiteboard.js
+++ b/whiteboard.js
@@ -6,7 +6,7 @@
         if (!whiteboardContainer) return;
 
         const e = React.createElement;
-        const Excalidraw = window.Excalidraw.Excalidraw;
+        const Excalidraw = window.ExcalidrawLib.Excalidraw;
 
         const Whiteboard = () => {
             const [excalidrawAPI, setExcalidrawAPI] = React.useState(null);


### PR DESCRIPTION
This commit fixes a bug where the whiteboard would not load due to a JavaScript error. The error occurred because the script was trying to access the Excalidraw component from an incorrect global variable.

- `whiteboard.js` is updated to use `window.ExcalidrawLib.Excalidraw` to access the component, as specified in the library's documentation for CDN usage.
- The script URLs in `index.html` have been updated to use React 18 and a more stable Excalidraw CDN link to prevent version mismatches.