### PR TITLE
fix: Correctly initialize Excalidraw component

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,9 +83,10 @@
     <button id="toggle-chat-btn" title="Cacher le panneau de chat">«</button>
     <button id="toggle-video-panel-btn" title="Cacher le panneau de vidéo">»</button>
 
-    <script type="text/javascript" src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script type="text/javascript" src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-    <script type="text/javascript" src="https://unpkg.com/@excalidraw/excalidraw/dist/excalidraw.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react@17/umd/react.development.js" crossorigin></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw@0.17.6/dist/excalidraw.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw@0.17.6/dist/excalidraw.production.min.js"></script>
 
     <script src="navigation.js" defer></script>
     <script src="script.js" defer></script>

--- a/whiteboard.js
+++ b/whiteboard.js
@@ -3,10 +3,29 @@
     // Wait for the main script to be loaded and the socket to be available
     document.addEventListener('DOMContentLoaded', () => {
         const whiteboardContainer = document.getElementById('whiteboard-container');
-        if (!whiteboardContainer) return;
+        if (!whiteboardContainer) {
+            console.error("Whiteboard container not found!");
+            return;
+        }
+
+        if (typeof React === 'undefined' || typeof ReactDOM === 'undefined') {
+            console.error("React or ReactDOM is not loaded!");
+            return;
+        }
 
         const e = React.createElement;
-        const Excalidraw = window.ExcalidrawLib.Excalidraw;
+        let ExcalidrawComponent;
+
+        if (window.ExcalidrawLib && window.ExcalidrawLib.Excalidraw) {
+            ExcalidrawComponent = window.ExcalidrawLib.Excalidraw;
+        } else if (window.Excalidraw && window.Excalidraw.Excalidraw) {
+            ExcalidrawComponent = window.Excalidraw.Excalidraw;
+        } else {
+            console.error("Excalidraw component not found on window object!");
+            whiteboardContainer.innerHTML = '<p>Error: Whiteboard library could not be loaded.</p>';
+            return;
+        }
+
 
         const Whiteboard = () => {
             const [excalidrawAPI, setExcalidrawAPI] = React.useState(null);


### PR DESCRIPTION
This commit fixes the issues with the collaborative whiteboard feature.

The main problem was related to script loading and initialization. This has been addressed by:
- Reverting to the official `@excalidraw/excalidraw` package from a CDN.
- Ensuring React and ReactDOM are loaded before the Excalidraw script in `index.html`.
- Making the initialization in `whiteboard.js` more robust by checking for the existence of the Excalidraw library on the `window` object before using it. This includes fallbacks for different ways the library might be exposed.

These changes should resolve the "Cannot read properties of undefined (reading 'Excalidraw')" error and allow the whiteboard to load correctly.