### PR TITLE
fix: Correct variable name for Excalidraw component

### DIFF
--- a/whiteboard.js
+++ b/whiteboard.js
@@ -66,7 +66,7 @@
             return e(
                 React.Fragment,
                 null,
-                e(Excalidraw, {
+                e(ExcalidrawComponent, {
                     excalidrawAPI: setExcalidrawAPI,
                     onChange: onChange,
                     initialData: {


### PR DESCRIPTION
This commit fixes a ReferenceError that occurred because the Excalidraw component was being referenced with an incorrect variable name inside the Whiteboard React component.

The variable `ExcalidrawComponent` was correctly assigned the component from the window object, but the `createElement` call was using the undefined variable `Excalidraw`. This has been corrected.

This change should resolve the `Uncaught ReferenceError: Excalidraw is not defined` and allow the whiteboard to render correctly.