### PR TITLE
feat: Add background image feature to Fabric.js whiteboard

### DIFF
--- a/fabric-whiteboard.js
+++ b/fabric-whiteboard.js
@@ -44,6 +44,50 @@
                 });
             }
         });
+
+        const handleBackgroundImage = (event) => {
+            if (!canvas || !event.target.files || event.target.files.length === 0) {
+                return;
+            }
+            const file = event.target.files[0];
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                const dataUrl = e.target.result;
+
+                // Send to other clients
+                if (window.socket && window.socket.readyState === WebSocket.OPEN) {
+                    window.socket.send(JSON.stringify({
+                        type: 'fabric-set-background',
+                        payload: dataUrl
+                    }));
+                }
+
+                // Apply locally
+                setBackground(dataUrl);
+            };
+            reader.readAsDataURL(file);
+        };
+
+        const setBackground = (dataUrl) => {
+            fabric.Image.fromURL(dataUrl, (img) => {
+                canvas.setBackgroundImage(img, canvas.renderAll.bind(canvas), {
+                    scaleX: canvas.width / img.width,
+                    scaleY: canvas.height / img.height
+                });
+            });
+        };
+
+        window.addEventListener('fabric-remote-set-background', (event) => {
+            if (canvas) {
+                const dataUrl = event.detail.payload;
+                setBackground(dataUrl);
+            }
+        });
+
+        const fileInput = document.getElementById('fabric-background-image-input');
+        if (fileInput) {
+            fileInput.addEventListener('change', handleBackgroundImage);
+        }
     };
 
     const observer = new MutationObserver((mutations) => {

--- a/index.html
+++ b/index.html
@@ -58,8 +58,12 @@
                 <div id="prez-content" class="tab-content" style="height: 100%;">
                     <div id="whiteboard-container" style="width: 100%; height: 100%;"></div>
                 </div>
-                <div id="fabric-content" class="tab-content" style="height: 100%;">
-                    <canvas id="fabric-canvas"></canvas>
+                <div id="fabric-content" class="tab-content" style="height: 100%; flex-direction: column;">
+                    <div class="whiteboard-controls">
+                        <input type="file" id="fabric-background-image-input" style="display: none;" accept="image/*" />
+                        <label for="fabric-background-image-input" class="control-btn btn-add" title="Set Background Image">+</label>
+                    </div>
+                    <canvas id="fabric-canvas" style="flex-grow: 1;"></canvas>
                 </div>
             </div>
             <nav class="main-menu">

--- a/script.js
+++ b/script.js
@@ -217,6 +217,10 @@
             case 'fabric-path-created':
                 window.dispatchEvent(new CustomEvent('fabric-remote-path-created', { detail: data }));
                 break;
+
+            case 'fabric-set-background':
+                window.dispatchEvent(new CustomEvent('fabric-remote-set-background', { detail: data }));
+                break;
         }
     };
 

--- a/server.js
+++ b/server.js
@@ -238,6 +238,15 @@ wss.on('connection', (ws) => {
                     }
                 });
                 break;
+
+            case 'fabric-set-background':
+                // Broadcast to all clients except the sender
+                clients.forEach(client => {
+                    if (client.ws !== ws && client.ws.readyState === WebSocket.OPEN) {
+                        client.ws.send(JSON.stringify(data));
+                    }
+                });
+                break;
         }
     });
 


### PR DESCRIPTION
This commit adds the ability for users to set a background image on the Fabric.js whiteboard.

Key changes:
- Adds a file input and a styled button to `index.html` to allow users to select an image file.
- Implements the logic in `fabric-whiteboard.js` to read the selected file as a data URL and set it as the canvas background using `canvas.setBackgroundImage`.
- Adds real-time synchronization for the background image. When a user sets a background, the image's data URL is broadcast to all other clients via a new `fabric-set-background` WebSocket message, ensuring all participants see the same background.