### PR TITLE
feat: Add toolbar with drawing tools to Fabric.js whiteboard

### DIFF
--- a/fabric-whiteboard.js
+++ b/fabric-whiteboard.js
@@ -1,5 +1,13 @@
 (() => {
     let canvas = null;
+    let activeTool = 'pencil';
+
+    const setActiveTool = (tool) => {
+        activeTool = tool;
+        if (canvas) {
+            canvas.isDrawingMode = tool === 'pencil';
+        }
+    };
 
     const initializeCanvas = () => {
         if (canvas) return;
@@ -88,6 +96,139 @@
         if (fileInput) {
             fileInput.addEventListener('change', handleBackgroundImage);
         }
+
+        const handleImageInput = (event) => {
+            if (!canvas || !event.target.files || event.target.files.length === 0) {
+                return;
+            }
+            const file = event.target.files[0];
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                const dataUrl = e.target.result;
+                fabric.Image.fromURL(dataUrl, (img) => {
+                    canvas.add(img);
+                    if (window.socket && window.socket.readyState === WebSocket.OPEN) {
+                        window.socket.send(JSON.stringify({
+                            type: 'fabric-add-object',
+                            payload: img.toJSON()
+                        }));
+                    }
+                });
+            };
+            reader.readAsDataURL(file);
+        };
+
+        const imageInput = document.getElementById('fabric-image-input');
+        if (imageInput) {
+            imageInput.addEventListener('change', handleImageInput);
+        }
+
+        // --- Drawing Logic ---
+        let isDrawing = false;
+        let startX, startY, currentShape;
+
+        canvas.on('mouse:down', (o) => {
+            if (activeTool === 'pencil' || !o.pointer) return;
+            isDrawing = true;
+            startX = o.pointer.x;
+            startY = o.pointer.y;
+
+            switch (activeTool) {
+                case 'line':
+                    currentShape = new fabric.Line([startX, startY, startX, startY], {
+                        stroke: '#ffffff',
+                        strokeWidth: 2
+                    });
+                    break;
+                case 'rect':
+                    currentShape = new fabric.Rect({
+                        left: startX,
+                        top: startY,
+                        width: 0,
+                        height: 0,
+                        stroke: '#ffffff',
+                        strokeWidth: 2,
+                        fill: 'transparent'
+                    });
+                    break;
+                case 'circle':
+                    currentShape = new fabric.Circle({
+                        left: startX,
+                        top: startY,
+                        radius: 0,
+                        stroke: '#ffffff',
+                        strokeWidth: 2,
+                        fill: 'transparent'
+                    });
+                    break;
+            }
+            if (currentShape) {
+                canvas.add(currentShape);
+            }
+        });
+
+        canvas.on('mouse:move', (o) => {
+            if (!isDrawing || !currentShape || !o.pointer) return;
+            const endX = o.pointer.x;
+            const endY = o.pointer.y;
+
+            switch (activeTool) {
+                case 'line':
+                    currentShape.set({ x2: endX, y2: endY });
+                    break;
+                case 'rect':
+                    currentShape.set({
+                        width: endX - startX,
+                        height: endY - startY
+                    });
+                    break;
+                case 'circle':
+                    currentShape.set({ radius: Math.abs(endX - startX) / 2 });
+                    break;
+            }
+            canvas.renderAll();
+        });
+
+        canvas.on('mouse:up', () => {
+            if (isDrawing && currentShape) {
+                const shapeJson = currentShape.toJSON();
+                if (window.socket && window.socket.readyState === WebSocket.OPEN) {
+                    window.socket.send(JSON.stringify({
+                        type: 'fabric-add-object',
+                        payload: shapeJson
+                    }));
+                }
+                isDrawing = false;
+                currentShape = null;
+            }
+        });
+
+        const addObjectToCanvas = (objJson) => {
+            fabric.util.enlivenObjects([objJson], function (objects) {
+                objects.forEach(function (obj) {
+                    canvas.add(obj);
+                });
+                canvas.renderAll();
+            });
+        };
+
+        window.addEventListener('fabric-remote-add-object', (event) => {
+            if (canvas) {
+                const objJson = event.detail.payload;
+                addObjectToCanvas(objJson);
+            }
+        });
+
+        // --- Toolbar Logic ---
+        const pencilTool = document.getElementById('fabric-pencil-tool');
+        const lineTool = document.getElementById('fabric-line-tool');
+        const rectTool = document.getElementById('fabric-rect-tool');
+        const circleTool = document.getElementById('fabric-circle-tool');
+
+        pencilTool.addEventListener('click', () => setActiveTool('pencil'));
+        lineTool.addEventListener('click', () => setActiveTool('line'));
+        rectTool.addEventListener('click', () => setActiveTool('rect'));
+        circleTool.addEventListener('click', () => setActiveTool('circle'));
     };
 
     const observer = new MutationObserver((mutations) => {

--- a/index.html
+++ b/index.html
@@ -60,8 +60,18 @@
                 </div>
                 <div id="fabric-content" class="tab-content" style="height: 100%; flex-direction: column;">
                     <div class="whiteboard-controls">
-                        <input type="file" id="fabric-background-image-input" style="display: none;" accept="image/*" />
-                        <label for="fabric-background-image-input" class="control-btn btn-add" title="Set Background Image">+</label>
+                        <div id="fabric-toolbar">
+                            <button id="fabric-pencil-tool" class="control-btn">Pencil</button>
+                            <button id="fabric-line-tool" class="control-btn">Line</button>
+                            <button id="fabric-rect-tool" class="control-btn">Rect</button>
+                            <button id="fabric-circle-tool" class="control-btn">Circle</button>
+                            <input type="file" id="fabric-image-input" style="display: none;" accept="image/*" />
+                            <label for="fabric-image-input" class="control-btn" title="Add Image">Img</label>
+                        </div>
+                        <div>
+                            <input type="file" id="fabric-background-image-input" style="display: none;" accept="image/*" />
+                            <label for="fabric-background-image-input" class="control-btn btn-add" title="Set Background Image">+</label>
+                        </div>
                     </div>
                     <canvas id="fabric-canvas" style="flex-grow: 1;"></canvas>
                 </div>

--- a/script.js
+++ b/script.js
@@ -221,6 +221,10 @@
             case 'fabric-set-background':
                 window.dispatchEvent(new CustomEvent('fabric-remote-set-background', { detail: data }));
                 break;
+
+            case 'fabric-add-object':
+                window.dispatchEvent(new CustomEvent('fabric-remote-add-object', { detail: data }));
+                break;
         }
     };
 

--- a/server.js
+++ b/server.js
@@ -247,6 +247,15 @@ wss.on('connection', (ws) => {
                     }
                 });
                 break;
+
+            case 'fabric-add-object':
+                // Broadcast to all clients except the sender
+                clients.forEach(client => {
+                    if (client.ws !== ws && client.ws.readyState === WebSocket.OPEN) {
+                        client.ws.send(JSON.stringify(data));
+                    }
+                });
+                break;
         }
     });
 

--- a/style.css
+++ b/style.css
@@ -151,6 +151,26 @@ body, html {
     color: #ffffff;
 }
 
+.whiteboard-controls {
+    padding: 5px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: #2c2c2c;
+    border-bottom: 1px solid #3a3a3a;
+    flex-shrink: 0;
+}
+
+#fabric-toolbar {
+    display: flex;
+    gap: 5px;
+}
+
+#fabric-toolbar .control-btn {
+    width: auto;
+    padding: 5px 10px;
+}
+
 /* --- Shared Controls Bar (for Sheets & Images) --- */
 .sheets-controls, .image-controls {
     display: flex;


### PR DESCRIPTION
This commit adds a toolbar to the Fabric.js whiteboard, providing users with a range of drawing tools.

Key features:
- A new toolbar with buttons for Pencil, Line, Rectangle, and Circle tools.
- Logic in `fabric-whiteboard.js` to handle tool switching and drawing of the corresponding shapes.
- An "Add Image" button that allows users to add images as objects to the canvas.
- Real-time synchronization for all new objects (lines, shapes, images) using WebSockets, ensuring a collaborative experience.
- Basic styling for the new toolbar and its buttons.