### PR TITLE
feat: Add drawing tools and element manipulation to Fabric.js whiteboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,8 @@
                             <button id="fabric-circle-tool" class="control-btn">Circle</button>
                             <input type="file" id="fabric-image-input" style="display: none;" accept="image/*" />
                             <label for="fabric-image-input" class="control-btn" title="Add Image">Img</label>
+                            <input type="color" id="fabric-color-picker" class="control-btn" title="Color Picker" />
+                            <button id="fabric-delete-tool" class="control-btn btn-delete" title="Delete">-</button>
                         </div>
                         <div>
                             <input type="file" id="fabric-background-image-input" style="display: none;" accept="image/*" />

--- a/script.js
+++ b/script.js
@@ -225,6 +225,14 @@
             case 'fabric-add-object':
                 window.dispatchEvent(new CustomEvent('fabric-remote-add-object', { detail: data }));
                 break;
+
+            case 'fabric-update-object':
+                window.dispatchEvent(new CustomEvent('fabric-remote-update-object', { detail: data }));
+                break;
+
+            case 'fabric-remove-object':
+                window.dispatchEvent(new CustomEvent('fabric-remote-remove-object', { detail: data }));
+                break;
         }
     };
 

--- a/server.js
+++ b/server.js
@@ -256,6 +256,24 @@ wss.on('connection', (ws) => {
                     }
                 });
                 break;
+
+            case 'fabric-update-object':
+                // Broadcast to all clients except the sender
+                clients.forEach(client => {
+                    if (client.ws !== ws && client.ws.readyState === WebSocket.OPEN) {
+                        client.ws.send(JSON.stringify(data));
+                    }
+                });
+                break;
+
+            case 'fabric-remove-object':
+                // Broadcast to all clients except the sender
+                clients.forEach(client => {
+                    if (client.ws !== ws && client.ws.readyState === WebSocket.OPEN) {
+                        client.ws.send(JSON.stringify(data));
+                    }
+                });
+                break;
         }
     });
 


### PR DESCRIPTION
This commit adds several new features to the Fabric.js whiteboard to make it more functional:
- A toolbar with tools for free drawing (Pencil), Line, Rectangle, and Circle.
- Logic to handle drawing these shapes on the canvas.
- An "Add Image" tool that resizes the image to half the canvas size upon insertion while maintaining aspect ratio.
- A color picker in the toolbar to change the color of the brush and selected elements.
- A "Delete" button and keyboard shortcut (Delete/Backspace) to remove selected elements.
- Real-time synchronization for all new actions (adding shapes/images, updating colors, deleting elements) via WebSockets.