### PR TITLE
fix: Correct whiteboard container width

### DIFF
--- a/style.css
+++ b/style.css
@@ -94,7 +94,6 @@ body, html {
     display: flex;
     flex-direction: column;
     gap: 10px; /* Replaces justify-content for consistent spacing */
-    align-items: center;
     background-color: #1e1e1e;
 }
 


### PR DESCRIPTION
This commit fixes a layout issue where the Fabric.js whiteboard container was not taking up the full width of the main content area.

The `align-items: center;` property has been removed from the `.main-content` rule in `style.css`, allowing the whiteboard container to expand to the full available width as intended.