### PR TITLE
fix: Final layout fix for Fabric.js whiteboard

### DIFF
--- a/fabric-whiteboard.js
+++ b/fabric-whiteboard.js
@@ -37,11 +37,18 @@
         if (!fabricContent || !canvasElement) return;
 
         const setCanvasSize = () => {
+            const controls = document.querySelector('.whiteboard-controls');
             const containerRect = fabricContent.getBoundingClientRect();
-            canvasElement.width = containerRect.width;
-            canvasElement.height = containerRect.height;
+            const controlsRect = controls.getBoundingClientRect();
+
+            const newWidth = containerRect.width;
+            const newHeight = containerRect.height - controlsRect.height;
+
+            canvasElement.width = newWidth;
+            canvasElement.height = newHeight;
+
             if (canvas) {
-                canvas.setDimensions({ width: containerRect.width, height: containerRect.height });
+                canvas.setDimensions({ width: newWidth, height: newHeight });
                 canvas.renderAll();
             }
         };
@@ -395,12 +402,13 @@
             if (canvas) {
                 clearTimeout(resizeTimeout);
                 resizeTimeout = setTimeout(() => {
-                    const setCanvasSize = () => {
-                        const containerRect = fabricContent.getBoundingClientRect();
-                        canvas.setDimensions({ width: containerRect.width, height: containerRect.height });
-                        canvas.renderAll();
-                    };
-                    setCanvasSize();
+                    const controls = document.querySelector('.whiteboard-controls');
+                    const containerRect = fabricContent.getBoundingClientRect();
+                    const controlsRect = controls.getBoundingClientRect();
+                    const newWidth = containerRect.width;
+                    const newHeight = containerRect.height - controlsRect.height;
+                    canvas.setDimensions({ width: newWidth, height: newHeight });
+                    canvas.renderAll();
                 }, 100);
             }
         });


### PR DESCRIPTION
This commit provides the final fix for the layout of the Fabric.js whiteboard. The canvas element was being sized incorrectly, causing it to overlap with the main navigation menu.

The fix involves:
- Modifying `fabric-whiteboard.js` to correctly calculate the canvas height. The height of the toolbar is now subtracted from the height of the main container, ensuring the canvas fits perfectly within the available space.
- This calculation is applied both on initial load and on window resize, making the layout robust.