### PR TITLE
fix: Correct fabric import in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const path = require('path');
 const fs = require('fs');
 const fetch = require('node-fetch');
 const chatbotConfig = require('./api.config.js');
-const fabric = require('fabric').fabric;
+const fabric = require('fabric');
 
 const app = express();
 


### PR DESCRIPTION
This corrects the import statement for the Fabric.js library in `server.js`. The previous import `require('fabric').fabric` was causing a `TypeError` and preventing the server from starting.

The import has been changed to `require('fabric')`, which is the correct way to import the library in a Node.js environment. This resolves the server crash.