### PR TITLE
fix: Call renderAll on server canvas to persist state

### DIFF
--- a/server.js
+++ b/server.js
@@ -258,6 +258,7 @@ wss.on('connection', (ws) => {
             case 'fabric-add-object':
                 fabric.util.enlivenObjects([data.payload], (objects) => {
                     objects.forEach(obj => serverCanvas.add(obj));
+                    serverCanvas.renderAll();
                     whiteboardState = JSON.stringify(serverCanvas.toJSON());
                 });
                 broadcastToOthers(ws, data);
@@ -266,6 +267,7 @@ wss.on('connection', (ws) => {
             case 'fabric-set-background':
                 fabric.Image.fromURL(data.payload, (img) => {
                     serverCanvas.setBackgroundImage(img, () => {
+                        serverCanvas.renderAll();
                         whiteboardState = JSON.stringify(serverCanvas.toJSON());
                     });
                 });
@@ -276,6 +278,7 @@ wss.on('connection', (ws) => {
                 const objToUpdate = serverCanvas.getObjects().find(obj => obj.id === data.payload.id);
                 if (objToUpdate) {
                     objToUpdate.set(data.payload);
+                    serverCanvas.renderAll();
                     whiteboardState = JSON.stringify(serverCanvas.toJSON());
                 }
                 broadcastToOthers(ws, data);
@@ -293,6 +296,7 @@ wss.on('connection', (ws) => {
                 const objToRemove = serverCanvas.getObjects().find(obj => obj.id === data.payload.id);
                 if (objToRemove) {
                     serverCanvas.remove(objToRemove);
+                    serverCanvas.renderAll();
                     whiteboardState = JSON.stringify(serverCanvas.toJSON());
                 }
                 broadcastToOthers(ws, data);


### PR DESCRIPTION
This commit resolves a critical bug where whiteboard modifications were not being persisted on the server, causing new users to see an outdated or empty canvas.

The issue was that after modifying the server-side `StaticCanvas` (e.g., adding or removing an object), a `renderAll()` call was missing. Without this call, the internal state of the canvas was not updated, and therefore `toJSON()` returned a stale representation.

This fix adds `serverCanvas.renderAll()` to all `fabric-*` message handlers in `server.js` immediately before the state is serialized and saved. This ensures that all changes are correctly captured and persisted.