### PR TITLE
fix: Enhance JSDOM environment to fix silent errors

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,6 +35,7 @@ let whiteboardState = null; // Will store the JSON of the fabric canvas
 const dom = new JSDOM(`<!DOCTYPE html><body><canvas></canvas></body>`);
 global.document = dom.window.document;
 global.window = dom.window;
+global.Image = dom.window.Image;
 
 const serverCanvas = new fabric.StaticCanvas(dom.window.document.querySelector('canvas'), { width: 1920, height: 1080 });
 whiteboardState = JSON.stringify(serverCanvas.toJSON()); // Initial empty state
@@ -300,7 +301,7 @@ wss.on('connection', (ws) => {
                         saveWhiteboardState(whiteboardState);
                         console.log('[WHITEBOARD] Background set and state saved.');
                     });
-                });
+                }, { crossOrigin: 'anonymous' });
                 broadcastToOthers(ws, data);
                 break;
 


### PR DESCRIPTION
This commit resolves a critical bug where Fabric.js async methods (`enlivenObjects`, `fromURL`) were failing silently on the server, preventing whiteboard state from being saved. User-provided logs confirmed that the callbacks for these methods were never being executed.

The root cause appears to be an incomplete virtual DOM environment provided by JSDOM. The fix involves two main changes to `server.js`:

1.  The `Image` constructor from the JSDOM instance is now assigned to `global.Image`. Fabric.js likely depends on this global object for creating and manipulating image objects, and its absence caused silent failures.
2.  A `crossOrigin: 'anonymous'` option has been added to the `fabric.Image.fromURL` call as a best practice to prevent potential canvas tainting issues, which can also lead to silent errors.

These changes create a more complete and stable environment for Fabric.js to run on the server, ensuring that the persistence logic is correctly executed.