### PR TITLE
fix: Correct fabric import for v5.x

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const path = require('path');
 const fs = require('fs');
 const fetch = require('node-fetch');
 const chatbotConfig = require('./api.config.js');
-const fabric = require('fabric');
+const { fabric } = require('fabric');
 const { JSDOM } = require('jsdom');
 
 const app = express();


### PR DESCRIPTION
This commit resolves a `TypeError: fabric.StaticCanvas is not a constructor` that occurred after downgrading the Fabric.js library to v5.3.0.

Different versions of the `fabric` npm package have different module structures. For v5.x, the main fabric object with the canvas constructors is nested. The import statement has been changed from `const fabric = require('fabric');` to `const { fabric } = require('fabric');` to correctly access the fabric object.

This change allows the server to start correctly with the downgraded library version, ensuring compatibility with the client.