### PR TITLE
fix: Pass null to StaticCanvas to prevent initialization error

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,7 +37,7 @@ global.document = dom.window.document;
 global.window = dom.window;
 global.Image = dom.window.Image;
 
-const serverCanvas = new fabric.StaticCanvas(dom.window.document.querySelector('canvas'), { width: 1920, height: 1080 });
+const serverCanvas = new fabric.StaticCanvas(null, { width: 1920, height: 1080 });
 whiteboardState = JSON.stringify(serverCanvas.toJSON()); // Initial empty state
 
 // --- Utility Functions ---


### PR DESCRIPTION
This commit resolves a `TypeError: The provided value is not of type 'Element'` that occurred during the initialization of `fabric.StaticCanvas` on the server.

The error was caused by passing a virtual DOM element from `jsdom` to the `StaticCanvas` constructor. The library was then attempting to perform browser-style measurements on this element, which failed within the `jsdom` environment.

The fix is to pass `null` as the first argument to the `StaticCanvas` constructor. This is the correct approach for creating a non-DOM-based, in-memory canvas for server-side use. The `jsdom` environment is still required to provide global `document` and `window` objects that the library's internal logic depends on, but the canvas itself is no longer tied to a specific element. This prevents the measurement-related crash.