### PR TITLE
fix: Improve scaling and update reliability

### DIFF
--- a/fabric-whiteboard.js
+++ b/fabric-whiteboard.js
@@ -306,8 +306,11 @@
                 const objJson = event.detail.payload;
                 const objToUpdate = canvas.getObjects().find(obj => obj.id === objJson.id);
                 if (objToUpdate) {
-                    objToUpdate.set(objJson);
-                    canvas.renderAll();
+                    canvas.remove(objToUpdate);
+                    fabric.util.enlivenObjects([objJson], (newObjects) => {
+                        canvas.add(newObjects[0]);
+                        canvas.renderAll();
+                    });
                 }
             }
         });

--- a/server.js
+++ b/server.js
@@ -300,6 +300,9 @@ wss.on('connection', (ws) => {
                         whiteboardState = JSON.stringify(serverCanvas.toJSON());
                         saveWhiteboardState(whiteboardState);
                         console.log('[WHITEBOARD] Background set and state saved.');
+                    }, {
+                        scaleX: serverCanvas.width / img.width,
+                        scaleY: serverCanvas.height / img.height
                     });
                 }, { crossOrigin: 'anonymous' });
                 broadcastToOthers(ws, data);
@@ -309,11 +312,15 @@ wss.on('connection', (ws) => {
                 console.log('[WHITEBOARD] Received fabric-update-object event.');
                 const objToUpdate = serverCanvas.getObjects().find(obj => obj.id === data.payload.id);
                 if (objToUpdate) {
-                    objToUpdate.set(data.payload);
-                    serverCanvas.renderAll();
-                    whiteboardState = JSON.stringify(serverCanvas.toJSON());
-                    saveWhiteboardState(whiteboardState);
-                    console.log('[WHITEBOARD] Object updated and state saved.');
+                    serverCanvas.remove(objToUpdate);
+                    fabric.util.enlivenObjects([data.payload], (newObjects) => {
+                        console.log('[WHITEBOARD] Enlivening updated object successful.');
+                        serverCanvas.add(newObjects[0]);
+                        serverCanvas.renderAll();
+                        whiteboardState = JSON.stringify(serverCanvas.toJSON());
+                        saveWhiteboardState(whiteboardState);
+                        console.log('[WHITEBOARD] Object updated (by replacement) and state saved.');
+                    });
                 }
                 broadcastToOthers(ws, data);
                 break;


### PR DESCRIPTION
This commit addresses three bugs reported by the user regarding the whiteboard's state management:

1.  **Incorrect Background Image Scaling**: The server was not applying scaling to the background image before saving the canvas state. This resulted in new users seeing a full-size, unscaled background. The fix adds the correct scaling logic to the `fabric-set-background` handler on the server.

2.  **Inconsistent Real-time Updates**: Real-time updates for modified objects were unreliable. This was due to using the `object.set()` method, which can be inconsistent.

3.  **State Reverting on Refresh**: Modified objects would revert to their previous state after a refresh. This was also caused by the unreliable `object.set()` method on the server, which failed to persist the updates correctly.

The fix for issues 2 and 3 is to replace the `object.set()` logic with a more robust remove-and-re-add pattern. When an object is updated, both the server (for persistence) and all other clients (for real-time sync) will now remove the old object and add a new instance created from the updated data. This ensures perfect synchronization and state persistence.