### PR TITLE
chore: Add detailed logging to saveWhiteboardState

### DIFF
--- a/server.js
+++ b/server.js
@@ -177,8 +177,10 @@ function broadcastImageList() {
 
 // --- Whiteboard State Functions ---
 function saveWhiteboardState(state) {
+    console.log(`[WHITEBOARD] Attempting to save state of length: ${state.length}`);
     try {
         fs.writeFileSync(WHITEBOARD_STATE_FILE, state);
+        console.log(`[WHITEBOARD] State successfully saved to ${WHITEBOARD_STATE_FILE}`);
     } catch (error) {
         console.error('[WHITEBOARD] FAILED to save state:', error);
     }


### PR DESCRIPTION
This commit adds more detailed logging to the `saveWhiteboardState` function in `server.js`. This is in response to user feedback that file-based persistence is not working as expected, to help diagnose the problem.

The new logs will show:
1.  When the save function is called.
2.  The size of the state string being saved, to verify that it's changing after modifications.
3.  A success message upon completion of `fs.writeFileSync`.

This will help determine if the save function is being called correctly, if the state is being updated properly in memory, and if the file write operation itself is succeeding without error.