### PR TITLE
fix: Ensure real-time synchronization for Fog of War

### DIFF
--- a/script.js
+++ b/script.js
@@ -235,6 +235,14 @@
                 window.dispatchEvent(new CustomEvent('fabric-remote-remove-object', { detail: data }));
                 break;
 
+            case 'fabric-fog-toggle':
+                window.dispatchEvent(new CustomEvent('fabric-fog-remote-toggle', { detail: data }));
+                break;
+
+            case 'fabric-fog-erase':
+                window.dispatchEvent(new CustomEvent('fabric-fog-remote-erase', { detail: data }));
+                break;
+
             case 'fabric-load':
                 window.dispatchEvent(new CustomEvent('fabric-load', { detail: data }));
                 break;


### PR DESCRIPTION
This commit fixes a bug where fog of war changes made by the MJ were not appearing for other users in real-time. The changes were only visible after a page reload.

The issue was caused by the main WebSocket message handler in `script.js` not forwarding the new fog-related messages (`fabric-fog-toggle` and `fabric-fog-erase`) to the whiteboard module.

This fix adds the necessary `case` statements to the handler to dispatch these events, re-establishing the real-time communication channel and ensuring all players see the fog of war updates as they happen.