### PR TITLE
fix: Correctly save and load fog layer properties

### DIFF
--- a/fabric-whiteboard.js
+++ b/fabric-whiteboard.js
@@ -18,7 +18,8 @@
         if (!canvas) return;
         clearTimeout(debounceTimeout);
         debounceTimeout = setTimeout(() => {
-            const state = JSON.stringify(canvas.toJSON(['id', 'isFog', 'isEraserPath']));
+            const propertiesToInclude = ['id', 'isFog', 'isEraserPath', 'selectable', 'evented'];
+            const state = JSON.stringify(canvas.toJSON(propertiesToInclude));
             if (window.socket && window.socket.readyState === WebSocket.OPEN) {
                 window.socket.send(JSON.stringify({
                     type: 'fabric-state-update',
@@ -378,6 +379,11 @@
             canvas.loadFromJSON(payload, () => {
                 fogLayer = canvas.getObjects().find(o => o.isFog && o.type === 'group') || null;
                 if (fogLayer) {
+                    // Defensively set properties to prevent interaction after reload
+                    fogLayer.set({
+                        selectable: false,
+                        evented: false,
+                    });
                     const fogBase = fogLayer.getObjects('rect')[0];
                     fogBase.set('fill', isMJ ? 'rgba(0,0,0,0.5)' : 'black');
                 }


### PR DESCRIPTION
This commit fixes two critical bugs related to the fog of war feature:
1. A coordinate mismatch for the eraser between the GM and other players.
2. The fog layer becoming a movable object for the GM after a page refresh, which also broke the eraser tool.

The root cause for both issues was that the `selectable` and `evented` properties of the fog layer group were not being saved to the JSON state. When the canvas was reloaded from the state, the fog layer would revert to the default (selectable) properties.

This fix addresses the issue by:
- Updating `canvas.toJSON()` to include `selectable` and `evented` in the list of serialized properties.
- Defensively re-applying `selectable: false` and `evented: false` to the fog layer after it's loaded from JSON.

This ensures the fog layer remains non-interactive after a page reload, which resolves the movability issue and, as a consequence, the eraser coordinate mismatch.