### PR TITLE
fix: Only allow GM to save authoritative whiteboard state

### DIFF
--- a/server.js
+++ b/server.js
@@ -278,8 +278,11 @@ wss.on('connection', (ws) => {
 
             // Persistence: save the full state received from a client
             case 'fabric-state-update':
-                whiteboardState = data.payload;
-                saveWhiteboardState(whiteboardState);
+                const clientState = clients.get(ws);
+                if (clientState && clientState.isMJ) {
+                    whiteboardState = data.payload;
+                    saveWhiteboardState(whiteboardState);
+                }
                 break;
 
             case 'pointer-move':


### PR DESCRIPTION
This commit fixes a critical bug where any client could overwrite the authoritative whiteboard state on the server. This caused inconsistencies, especially with the fog of war feature, as a player's view (with solid black fog) could be saved over the GM's view (with semi-transparent fog).

The fix is to add an authorization check in the `fabric-state-update` message handler on the server. The server now verifies that the client sending the state update is the GM (`isMJ` is true) before accepting and saving the state. This ensures that the GM's canvas is always the source of truth, resolving the state corruption and coordinate mismatch issues.