### PR TITLE
fix: Include position in real-time eraser path updates

### DIFF
--- a/fabric-whiteboard.js
+++ b/fabric-whiteboard.js
@@ -322,7 +322,7 @@
                 canvas.remove(currentShape); // remove the temp path
                 addFogEraserPath(currentShape);
                 if (window.socket?.readyState === WebSocket.OPEN) {
-                    window.socket.send(JSON.stringify({ type: 'fabric-fog-erase', payload: currentShape.toJSON(['id', 'isEraserPath']) }));
+                    window.socket.send(JSON.stringify({ type: 'fabric-fog-erase', payload: currentShape.toJSON(['id', 'isEraserPath', 'left', 'top']) }));
                 }
             } else if (isDrawing && currentShape) {
                 if (window.socket?.readyState === WebSocket.OPEN) {


### PR DESCRIPTION
This commit fixes the final remaining bug in the fog of war feature, where eraser strokes made by the GM would appear at an incorrect, offset position on other players' screens in real-time.

The root cause was that the `left` and `top` properties of the `fabric.Path` object were not being included in the JSON payload sent over WebSockets for the `fabric-fog-erase` event. This meant remote clients would render the correct path shape, but at the default (0,0) origin instead of its true position.

The fix is to add `left` and `top` to the list of properties in the `toJSON()` call when serializing the eraser path for broadcast. This ensures remote clients receive the correct origin and render the path in the exact same location as on the GM's canvas.