### PR TITLE
fix: Restore eraser functionality for GM

### DIFF
--- a/fabric-whiteboard.js
+++ b/fabric-whiteboard.js
@@ -333,7 +333,7 @@
             canvas.clearContext(canvas.contextTop); // Clear feedback drawing
             if (isErasingFog && currentEraserPathData.length > 1) {
                 const path = new fabric.Path(currentEraserPathData, {
-                    stroke: 'transparent',
+                    stroke: 'white',
                     strokeWidth: fogBrushSize,
                     strokeLineCap: 'round',
                     strokeLineJoin: 'round',


### PR DESCRIPTION
This commit fixes a regression introduced in the previous patch where the fog of war eraser tool stopped working for the GM.

The cause was that the `fabric.Path` object for the eraser stroke was being created with a `stroke: 'transparent'` property. The `destination-out` composite operation, which creates the erasing effect, requires an opaque source shape to "knock out" the pixels of the destination. A transparent stroke resulted in no effect.

This fix changes the stroke color back to `'white'`, restoring the necessary opacity and making the eraser functional again.