### PR TITLE
feat: Add OpenAI-compatible chatbot template

### DIFF
--- a/api.config.js
+++ b/api.config.js
@@ -44,6 +44,21 @@ const chatbotConfig = {
         apiKey: apiKeys.mistral
     },
     */
+
+    // --- Example for a custom OpenAI-compatible API ---
+    // To use, a user would type: "#custombot <your prompt>"
+    // To enable, uncomment this section and provide your details.
+    /*
+    '#custombot': {
+        type: 'paid',
+        service: 'openai-compatible',
+        displayName: 'Custom Bot', // Optional: The name displayed in chat
+        model: 'chat', // The model name your API expects
+        apiKey: apiKeys.custombot, // Add your key to apikeys.js
+        endpoint: 'http://YOUR_BOT_URL/v1/chat/completions',
+        systemPrompt: 'You are a helpful assistant.' // The system message
+    },
+    */
 };
 
 module.exports = chatbotConfig;


### PR DESCRIPTION
This commit introduces a new chatbot provider type, `openai-compatible`, to allow integration with custom chatbots that use the OpenAI API format.

- Adds a new configuration template to `api.config.js` for the `openai-compatible` service. This includes options for the endpoint URL, model name, API key, and a system prompt.

- Extends `server.js` to handle the new service type. The `handleChatbotRequest` function now constructs and sends a POST request with the correct `X-API-Key` header and a JSON body that conforms to the OpenAI `v1/chat/completions` standard.

This change directly addresses the user's request to add a custom chatbot using a specific curl command format.