### PR TITLE
feat: Add --nossl flag for flexible server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ You need to have [Node.js](https://nodejs.org/) and [npm](https://www.npmjs.com/
     ```sh
     node server.js
     ```
-    The server will start and be accessible at `https://localhost:3000`.
+
+    The server will start in HTTPS mode by default.
+
+    #### Running without SSL (for Gitpod, Codespaces, etc.)
+    If you are running this application behind a reverse proxy that already provides SSL (like GitHub Codespaces or Gitpod), you may get a "502 Bad Gateway" error. To solve this, run the server with the `--nossl` flag to disable the built-in HTTPS:
+    ```sh
+    node server.js --nossl
+    ```
+    The server will start in HTTP mode and should be accessible through your proxy's secure URL.
 
 3.  **Open the Application**
 

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const http = require('http');
 const https = require('https');
 const WebSocket = require('ws');
 const path = require('path');
@@ -7,12 +8,21 @@ const fetch = require('node-fetch');
 const chatbotConfig = require('./api.config.js');
 const app = express();
 
-const options = {
-    key: fs.readFileSync(path.join(__dirname, 'certs/key.pem')),
-    cert: fs.readFileSync(path.join(__dirname, 'certs/cert.pem'))
-};
+const useSSL = !process.argv.includes('--nossl');
+let server;
 
-const server = https.createServer(options, app);
+if (useSSL) {
+    console.log('[SERVER] Starting in HTTPS mode.');
+    const options = {
+        key: fs.readFileSync(path.join(__dirname, 'certs/key.pem')),
+        cert: fs.readFileSync(path.join(__dirname, 'certs/cert.pem'))
+    };
+    server = https.createServer(options, app);
+} else {
+    console.log('[SERVER] Starting in HTTP mode (SSL disabled).');
+    server = http.createServer(app);
+}
+
 const wss = new WebSocket.Server({ server });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
This commit introduces a `--nossl` command-line flag to provide more flexible server startup options.

- When the `--nossl` flag is provided, the server will start in HTTP mode. This is useful for environments like GitHub Codespaces or Gitpod, where a reverse proxy handles SSL termination and an internal HTTPS server can cause 502 errors.
- If the flag is not present, the server defaults to its original behavior, starting in HTTPS mode with the self-signed certificate.
- The README.md has been updated to document this new flag and its use case.