### PR TITLE
feat: Implement flexible configuration and new chatbot type

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,13 @@ The server will attempt to load the following files if they exist:
 *Example `api.user.js` for Production:*
 See the `api.user.js.example` file for a template.
 ```javascript
-// /etc/secrets/api.user.js
+// In /etc/secrets/api.user.js
 const userChatbotConfig = {
   '#ubot': {
     type: 'paid',
     service: 'openai-compatible',
     displayName: 'U-Bot (Production)',
-    // The apiKey value 'ubot_prod_key' must have a corresponding
-    // entry in your /etc/secrets/apikeys.js file.
+    // This string MUST match a key in your apikeys.js file.
     apiKey: 'ubot_prod_key',
     endpoint: 'https://my-chatbot-url.com/v1/chat/completions'
   }
@@ -129,8 +128,9 @@ module.exports = userChatbotConfig;
 ```
 *Example `apikeys.js` for Production:*
 ```javascript
-// /etc/secrets/apikeys.js
+// In /etc/secrets/apikeys.js
 module.exports = {
+    // This key is referenced by the 'apiKey' string in api.user.js
     ubot_prod_key: 'PASTE_YOUR_PRODUCTION_API_KEY_HERE'
 };
 ```

--- a/server.js
+++ b/server.js
@@ -269,7 +269,15 @@ wss.on('connection', (ws) => {
             const trigger = Object.keys(chatbotConfig).find(key => data.message.startsWith(key));
             if (trigger) {
                 const prompt = data.message.substring(trigger.length).trim();
-                handleChatbotRequest(prompt, chatbotConfig[trigger], trigger);
+                const config = { ...chatbotConfig[trigger] }; // Clone to avoid modifying the original object
+
+                // If the apiKey is a string, it's treated as a key name to look up in the apiKeys object.
+                // This allows configs to refer to keys without having direct access to the apiKeys object.
+                if (typeof config.apiKey === 'string' && apiKeys[config.apiKey]) {
+                    config.apiKey = apiKeys[config.apiKey];
+                }
+
+                handleChatbotRequest(prompt, config, trigger);
                 return;
             }
         }


### PR DESCRIPTION
This commit introduces a suite of features to enhance the application's flexibility, configurability, and deployment readiness.

1.  **OpenAI-Compatible Chatbot:**
    - Adds a new `openai-compatible` service type to the chatbot feature, allowing integration with any chatbot that follows the OpenAI API standard.

2.  **Flexible Server Startup:**
    - Introduces a `--nossl` command-line flag to run the server in HTTP mode. This is essential for deployment environments like GitHub Codespaces or Render that manage their own SSL termination.

3.  **Layered Configuration System:**
    - The server now supports a layered configuration system for deployment environments.
    - It automatically attempts to load API keys from `/etc/secrets/apikeys.js` and a custom chatbot configuration from `/etc/secrets/api.user.js`.
    - If these files are not found, it gracefully falls back to using the local `apikeys.js` and `api.config.js`.
    - The custom configuration is merged over the base configuration.

4.  **API Key Resolution:**
    - The `apiKey` property in the chatbot configuration now acts as a key name. The server resolves this name against the loaded secrets from the `apikeys.js` file to find the actual API key value.

5.  **Updated Documentation:**
    - The `README.md` has been thoroughly updated to document all new features.
    - New example files (`api.user.js.example`) have been added to guide users.