### PR TITLE
Introduce a system for game-specific dice roll rules.

### DIFF
--- a/game-systems.js
+++ b/game-systems.js
@@ -3,10 +3,10 @@
     const gameSystems = {
         cypher: {
             name: 'Cypher System',
-            help: '<strong>/cypher</strong> [/D difficulté] [/E effort] [/H malus] - Lance un dé pour le Cypher System.',
+            help: '<strong>/cypher</strong> [/D difficulté] [/E effort] [/M malus] - Lance un dé pour le Cypher System.',
             roll: (args) => {
                 // --- Argument Parsing ---
-                const params = { D: 0, E: 0, H: 0 };
+                const params = { D: 0, E: 0, M: 0 };
                 for (let i = 0; i < args.length; i++) {
                     const param = args[i].toUpperCase();
                     if (params.hasOwnProperty(param.substring(1))) {
@@ -17,13 +17,13 @@
                         }
                     }
                 }
-                const { D: difficulty, E: effort, H: hindrance } = params;
+                const { D: difficulty, E: effort, M: malus } = params;
 
                 const roll = Math.floor(Math.random() * 20) + 1;
                 let resultText = `Jet : <strong>${roll}</strong>. `;
 
                 // --- Case 1: No parameters provided ---
-                if (difficulty === 0 && effort === 0 && hindrance === 0) {
+                if (difficulty === 0 && effort === 0 && malus === 0) {
                     const beatenDifficulty = Math.floor(roll / 3);
                     resultText += `Le jet brut bat une difficulté de <strong>${beatenDifficulty}</strong> (cible ${beatenDifficulty * 3}).`;
                      if (roll === 1) {
@@ -36,14 +36,14 @@
 
                 // --- Case 2: Parameters are provided ---
                 const target = difficulty * 3;
-                const modifiedRoll = roll + (effort * 3) - (hindrance * 3);
+                const modifiedRoll = roll + (effort * 3) - (malus * 3);
 
                 resultText = `Difficulté ${difficulty} (cible > ${target}).`;
                 resultText += ` Jet : <strong>${roll}</strong>`;
 
                 if (effort > 0) resultText += ` + ${effort * 3} (Effort)`;
-                if (hindrance > 0) resultText += ` - ${hindrance * 3} (Malus)`;
-                if (effort > 0 || hindrance > 0) resultText += `. Total modifié : <strong>${modifiedRoll}</strong>`;
+                if (malus > 0) resultText += ` - ${malus * 3} (Malus)`;
+                if (effort > 0 || malus > 0) resultText += `. Total modifié : <strong>${modifiedRoll}</strong>`;
 
                 if (roll === 1) {
                     resultText += '<br><strong>Échec critique !</strong> Le MJ peut introduire une intrusion.';


### PR DESCRIPTION
- Create a new `game-systems.js` file to house the logic for different game systems, making it easily extensible.
- Implement the Cypher System as the first game system, including rules for difficulty, effort, and malus.
- Add a `/help` command to display available commands.
- Add a `/cypher` command to trigger Cypher System rolls, with support for named, optional, and out-of-order parameters (`/D`, `/E`, `/M`).
- Implement a parameter-less `/cypher` roll that determines the beaten difficulty level.
- Style the output of game-specific rolls with a light yellow background.
- Update the server to handle and log the new `game-roll` message type.