### PR TITLE
refactor: Improve styling of panel toggle buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,8 +138,12 @@
         </aside>
 
         <!-- Panel Toggles -->
-        <button id="toggle-chat-btn" title="Cacher le panneau de chat">«</button>
-        <button id="toggle-video-panel-btn" title="Cacher le panneau de vidéo">»</button>
+        <button id="toggle-chat-btn" title="Cacher le panneau de chat">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" /></svg>
+        </button>
+        <button id="toggle-video-panel-btn" title="Cacher le panneau de vidéo">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /></svg>
+        </button>
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.3.1/fabric.min.js"></script>

--- a/script.js
+++ b/script.js
@@ -312,6 +312,7 @@
                     const isNowHidden = item.panel.classList.contains(item.class);
 
                     item.resizer.style.display = isNowHidden ? 'none' : 'block';
+                    item.btn.classList.toggle('collapsed', isNowHidden);
 
                     if (isNowHidden) {
                         // Remove inline style so the CSS class can position the button at the edge
@@ -321,24 +322,13 @@
                         const panelWidthVar = getComputedStyle(item.panel).getPropertyValue(`--${item.side}-panel-width`);
                         item.btn.style[item.side] = `calc(${panelWidthVar} - ${item.btn.offsetWidth}px)`;
                     }
-
-                    // Update button text/icon based on state
-                    if (item.btn.id === 'toggle-chat-btn') {
-                        item.btn.textContent = isNowHidden ? '»' : '«';
-                    } else {
-                        item.btn.textContent = isNowHidden ? '«' : '»';
-                    }
                 });
 
                 // Initial state check
                 const initiallyHidden = item.panel.classList.contains(item.class);
                 if (initiallyHidden) {
                     item.resizer.style.display = 'none';
-                    if (item.btn.id === 'toggle-chat-btn') {
-                        item.btn.textContent = '»';
-                    } else {
-                        item.btn.textContent = '«';
-                    }
+                    item.btn.classList.add('collapsed');
                 }
             }
         });

--- a/style.css
+++ b/style.css
@@ -69,21 +69,29 @@ body, html {
     top: 50%;
     transform: translateY(-50%);
     z-index: 100;
-    background: #2a2a2a;
+    background: #3a3a3a; /* Lighter than panel background */
     color: #eee;
-    border: 1px solid #333;
-    border-radius: 0 4px 4px 0; /* Rounded on one side */
-    width: 20px;
+    border: 1px solid #444;
+    border-radius: 0 4px 4px 0;
+    width: 24px;
     height: 60px;
-    line-height: 60px;
-    text-align: center;
     cursor: pointer;
     box-shadow: 0 2px 5px rgba(0,0,0,0.5);
     transition: all 0.3s ease-in-out;
-    writing-mode: vertical-rl; /* Vertical text */
-    text-orientation: mixed;
-    font-size: 14px;
-    padding: 5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+}
+
+#toggle-chat-btn .icon, #toggle-video-panel-btn .icon {
+    width: 16px;
+    height: 16px;
+    transition: transform 0.3s ease-in-out;
+}
+
+#toggle-chat-btn.collapsed .icon, #toggle-video-panel-btn.collapsed .icon {
+    transform: rotate(180deg);
 }
 
 #toggle-chat-btn {


### PR DESCRIPTION
This commit refactors the styling of the panel toggle buttons based on user feedback.

- Replaces the text characters (`«` and `»`) with SVG chevron icons for a cleaner look.
- Makes the background color of the toggle buttons lighter to distinguish them from the side panels.
- The SVG icons now rotate 180 degrees to indicate the collapsed/expanded state of the panels, driven by a CSS class toggle in the JavaScript.