### PR TITLE
fix(music): Ensure playlist data is broadcast to all clients

### DIFF
--- a/server.js
+++ b/server.js
@@ -489,9 +489,9 @@ wss.on('connection', (ws) => {
                         return; // Don't broadcast or save
                 }
 
-                // After any change, save and broadcast the full playlist to the MJ
+                // After any change, save and broadcast the full playlist to all clients
                 savePlaylist();
-                broadcastToMJ({ type: 'music-control', action: 'playlist-update', value: { playlist: musicState.playlist, isLooping: musicState.isLooping } });
+                broadcast({ type: 'music-control', action: 'playlist-update', value: { playlist: musicState.playlist, isLooping: musicState.isLooping } });
                 break;
 
             case 'add-image':


### PR DESCRIPTION
Previously, the `playlist-update` message was only sent to the MJ. This prevented non-MJ clients from being able to play music, as they lacked the necessary video information when a `play` command was received.

This commit changes the `broadcastToMJ` call to `broadcast` for playlist updates, ensuring all clients are synced and can play music.