### PR TITLE
fix(music): Fetch video titles on client to remove API key dependency

### DIFF
--- a/apikeys.js.example
+++ b/apikeys.js.example
@@ -12,8 +12,7 @@
 
 const apiKeys = {
     gemini: 'PASTE_YOUR_GOOGLE_GEMINI_API_KEY_HERE',
-    mistral: 'PASTE_YOUR_MISTRAL_API_KEY_HERE',
-    youtube: 'PASTE_YOUR_GOOGLE_YOUTUBE_DATA_API_KEY_HERE'
+    mistral: 'PASTE_YOUR_MISTRAL_API_KEY_HERE'
 };
 
 module.exports = apiKeys;


### PR DESCRIPTION
This commit refactors the music feature to resolve a regression where video titles were not appearing in the playlist without a YouTube API key.

The title-fetching mechanism has been moved from the server to the client. A temporary, non-disruptive YouTube player instance is now created in `music.js` to get video metadata directly from the IFrame API.

Changes:
- `server.js`: Removed `getYouTubeVideoTitle` and the server-side API call logic. The server now accepts the title from the client.
- `music.js`: Implemented a new `handleAddClick` flow that creates a temporary player to fetch the title before adding a song to the playlist.
- `apikeys.js.example`: Removed the unnecessary `youtube` API key field.