### PR TITLE
Fix image buttons visibility and remove Prez menu

### DIFF
--- a/images.js
+++ b/images.js
@@ -58,7 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- WebSocket Event Listeners (via window events) ---
 
     function showMJControls() {
-        imageControls.classList.remove('hidden');
+        imageControls.style.display = 'flex';
     }
 
     window.addEventListener('mj-status', (e) => {

--- a/index.html
+++ b/index.html
@@ -57,9 +57,6 @@
                         <!-- L'iframe de la Google Sheet ira ici -->
                     </div>
                 </div>
-                <div id="prez-content" class="tab-content" style="height: 100%;">
-                    <div id="whiteboard-container" style="width: 100%; height: 100%;"></div>
-                </div>
                 <div id="fabric-content" class="tab-content">
                     <div class="whiteboard-controls">
                         <div id="fabric-toolbar">
@@ -137,7 +134,6 @@
             <nav class="main-menu">
                 <a href="#carte" class="menu-item" data-target="carte-content" title="Carte"><span class="material-symbols-outlined">map</span></a>
                 <a href="#pj" class="menu-item" data-target="pj-content" title="Personnages"><span class="material-symbols-outlined">group</span></a>
-                <a href="#prez" class="menu-item" data-target="prez-content" title="Présentation"><span class="material-symbols-outlined">slideshow</span></a>
                 <a href="#fabric" class="menu-item" data-target="fabric-content" title="Tableau Blanc"><span class="material-symbols-outlined">draw</span></a>
                 <a href="#music" class="menu-item hidden" data-target="music-content" id="music-nav-item" title="Musique"><span class="material-symbols-outlined">music_note</span></a>
             </nav>


### PR DESCRIPTION
This commit addresses follow-up feedback from the user.

1.  **Fix Image Buttons Visibility:**
    - The image controls for the MJ were still not reliably appearing. The previous fix of removing the 'hidden' class was not sufficient.
    - The `images.js` script is now updated to directly set the `display` style of the `.image-controls` element to `flex`. This is a more robust method to ensure the controls are visible and overrides any conflicting CSS.

2.  **Remove "Prez" Menu:**
    - The unused "Prez" (Presentation) menu item has been removed from the navigation bar in `index.html`.
    - The corresponding `<div id="prez-content">` has also been removed from the HTML to keep the codebase clean.