### PR TITLE
Fix: Correct MJ controls visibility and implement wiki persistence

### DIFF
--- a/images.js
+++ b/images.js
@@ -58,7 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- WebSocket Event Listeners (via window events) ---
 
     function showMJControls() {
-        imageControls.style.display = 'flex';
+        imageControls.classList.remove('hidden');
     }
 
     window.addEventListener('mj-status', (e) => {


### PR DESCRIPTION
This commit addresses two issues:
1.  The MJ-only controls for image management were not appearing. This was because the `.hidden` class in the CSS uses `display: none !important;`, which prevented the JavaScript's inline `style.display` from working. The code has been corrected to use `classList.remove('hidden')` which correctly shows the controls.

2.  Wiki pages were not being saved and disappeared on refresh. This was because the server lacked any persistence logic for the wiki. A full backend implementation has been added to `server.js` to handle this:
    -   The server now reads and loads `.md` files from the `/wiki` and `/wiki/mj` directories on startup.
    -   WebSocket message handlers for `wiki-get-page` and `wiki-save-page` have been added to read from and write to these files.
    -   The server now broadcasts the list of available pages to clients on connection and after any page is saved, ensuring the UI is always in sync.
    -   This new backend logic is compatible with the existing client-side code in `wiki.js`.