### PR TITLE
Fix: Correct socket reference in images.js

### DIFF
--- a/images.js
+++ b/images.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
     // Note: The global `socket` is exposed by script.js
-    if (typeof socket === 'undefined') {
+    if (typeof window.socket === 'undefined') {
         console.error('Socket is not available. Make sure script.js is loaded first.');
         return;
     }
@@ -32,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        socket.send(JSON.stringify({ type: 'add-image', name, url }));
+        window.socket.send(JSON.stringify({ type: 'add-image', name, url }));
     }
 
     function handleDeleteImage() {
@@ -40,7 +40,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (selectedUrl) {
             const selectedName = imageSelect.options[imageSelect.selectedIndex].text;
             if (confirm(`Êtes-vous sûr de vouloir supprimer l'image "${selectedName}" ?`)) {
-                socket.send(JSON.stringify({ type: 'delete-image', url: selectedUrl }));
+                window.socket.send(JSON.stringify({ type: 'delete-image', url: selectedUrl }));
             }
         } else {
             alert('Veuillez sélectionner une image à supprimer.');
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // The 'show-image' event is sent even for the placeholder,
         // which will have an empty value. The server will broadcast this,
         // and the client will clear the image display.
-        socket.send(JSON.stringify({ type: 'show-image', url: selectedUrl }));
+        window.socket.send(JSON.stringify({ type: 'show-image', url: selectedUrl }));
     }
 
     // --- WebSocket Event Listeners (via window events) ---


### PR DESCRIPTION
This commit fixes a bug in `images.js` that was preventing the MJ (Game Master) controls from appearing on the image management tab.

The script was attempting to use a local `socket` variable, which was not defined in its scope, instead of the global `window.socket` object provided by `script.js`. This caused a `ReferenceError` that halted script execution, preventing the `mj-status` event listener from being attached and the controls from being displayed.

All references to `socket` within `images.js` have been corrected to `window.socket`, bringing it in line with the other client-side scripts and ensuring it can correctly interact with the WebSocket connection.