### PR TITLE
Fix: Correct MJ controls visibility and improve wiki UI

### DIFF
--- a/images.js
+++ b/images.js
@@ -57,16 +57,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- WebSocket Event Listeners (via window events) ---
 
-    function showMJControls() {
-        imageControls.classList.remove('hidden');
-    }
-
-    window.addEventListener('mj-status', (e) => {
-        if (e.detail.isMJ) {
-            showMJControls();
-        }
-    });
-
     window.addEventListener('image-list-update', (e) => {
         const imageList = e.detail.list;
         const selectedValue = imageSelect.value;
@@ -89,11 +79,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // --- Initial Setup ---
-
-    // Check the global flag on load, in case the event was missed
-    if (window.isMJ) {
-        showMJControls();
-    }
 
     addImageBtn.addEventListener('click', handleAddImage);
     deleteImageBtn.addEventListener('click', handleDeleteImage);

--- a/script.js
+++ b/script.js
@@ -263,6 +263,12 @@
                 case 'mj-status':
                     window.isMJ = data.isMJ; // Set the global flag
                     window.dispatchEvent(new CustomEvent('mj-status', { detail: { isMJ: data.isMJ } }));
+
+                    // Directly control image controls visibility
+                    const imageControls = document.querySelector('.image-controls');
+                    if (imageControls) {
+                        imageControls.classList.toggle('hidden', !data.isMJ);
+                    }
                     break;
                 case 'image-list-update':
                     window.dispatchEvent(new CustomEvent('image-list-update', { detail: { list: data.list } }));

--- a/wiki.css
+++ b/wiki.css
@@ -33,6 +33,13 @@
     margin: 10px 0 0 0;
 }
 
+#wiki-mj-page-list {
+    max-height: 250px; /* Limit the height of the MJ list */
+    overflow-y: auto; /* Make it scrollable if it overflows */
+    padding-right: 5px; /* Add some padding so the scrollbar doesn't hug the text */
+    margin-bottom: 10px;
+}
+
 .wiki-sidebar ul li {
     padding: 8px 10px;
     cursor: pointer;
@@ -55,7 +62,7 @@
     width: 100%;
     padding: 8px;
     margin-bottom: 10px;
-    background-color: #4CAF50;
+    background-color: #2196F3; /* Blue, to distinguish from green active item */
     color: white;
     border: none;
     border-radius: 5px;
@@ -64,7 +71,7 @@
 }
 
 .new-page-btn:hover {
-    background-color: #45a049;
+    background-color: #1e88e5; /* Darker blue on hover */
 }
 
 .wiki-main {


### PR DESCRIPTION
This commit addresses three issues reported by the user:
1.  The MJ-only image controls were not appearing. The logic has been centralized in `script.js` to directly toggle the visibility of the controls when the `mj-status` message is received. This avoids any potential race conditions or script-loading issues.
2.  The MJ-specific menu in the wiki sidebar was too large. A `max-height` and `overflow-y: auto` have been added to its CSS to make it smaller and scrollable.
3.  The 'New Page' button in the wiki was the same color as a selected page. The button's background color has been changed to blue to make it visually distinct.