### PR TITLE
Feat: Redesign wiki UI and fix image control event listeners

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,32 +133,29 @@
                     <div id="youtube-player"></div>
                 </div>
                 <div id="wiki-content" class="tab-content">
-                    <div class="wiki-container">
-                        <div class="wiki-sidebar">
-                            <h3>Pages</h3>
-                            <ul id="wiki-page-list">
-                                <!-- Page list will be populated by JS -->
-                            </ul>
-                            <div class="wiki-sidebar-controls hidden" id="wiki-mj-controls">
-                                <h3>MJ Zone</h3>
-                                <ul id="wiki-mj-page-list">
-                                    <!-- MJ page list will be populated by JS -->
-                                </ul>
-                            </div>
+                    <div class="wiki-controls">
+                        <select id="wiki-page-select">
+                            <option value="">Choisir une page</option>
+                        </select>
+                        <button id="wiki-add-page-btn" class="control-btn btn-add" title="Ajouter une page publique">
+                            <span class="material-symbols-outlined">add</span>
+                        </button>
+                        <button id="wiki-add-mj-page-btn" class="control-btn btn-delete hidden" title="Ajouter une page MJ">
+                            <span class="material-symbols-outlined">add</span>
+                        </button>
+                    </div>
+                    <div class="wiki-main">
+                        <div id="wiki-viewer">
+                            <h2 id="wiki-title"></h2>
+                            <div id="wiki-body"></div>
                         </div>
-                        <div class="wiki-main">
-                            <div id="wiki-viewer">
-                                <h2 id="wiki-title"></h2>
-                                <div id="wiki-body"></div>
-                            </div>
-                            <div id="wiki-editor" style="display: none;">
-                                <input type="text" id="wiki-editor-title" placeholder="Titre de la page" />
-                                <textarea id="wiki-textarea"></textarea>
-                                <button id="wiki-save-btn">Sauvegarder</button>
-                                <button id="wiki-cancel-btn">Annuler</button>
-                            </div>
-                             <button id="wiki-edit-btn">Modifier</button>
+                        <div id="wiki-editor" style="display: none;">
+                            <input type="text" id="wiki-editor-title" placeholder="Titre de la page" />
+                            <textarea id="wiki-textarea"></textarea>
+                            <button id="wiki-save-btn">Sauvegarder</button>
+                            <button id="wiki-cancel-btn">Annuler</button>
                         </div>
+                         <button id="wiki-edit-btn">Modifier</button>
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -260,16 +260,24 @@
                         }
                     });
                     break;
-                case 'mj-status':
+                case 'mj-status': { // Use block scope
                     window.isMJ = data.isMJ; // Set the global flag
                     window.dispatchEvent(new CustomEvent('mj-status', { detail: { isMJ: data.isMJ } }));
 
-                    // Directly control image controls visibility
+                    // Directly control image controls visibility and attach listeners
                     const imageControls = document.querySelector('.image-controls');
                     if (imageControls) {
+                        const isHidden = imageControls.classList.contains('hidden');
+                        if (data.isMJ && isHidden) {
+                            // First time showing, attach listeners
+                            document.getElementById('add-image-btn')?.addEventListener('click', window.imageHandlers.handleAddImage);
+                            document.getElementById('delete-image-btn')?.addEventListener('click', window.imageHandlers.handleDeleteImage);
+                            document.getElementById('image-select')?.addEventListener('change', window.imageHandlers.handleShowImage);
+                        }
                         imageControls.classList.toggle('hidden', !data.isMJ);
                     }
                     break;
+                }
                 case 'image-list-update':
                     window.dispatchEvent(new CustomEvent('image-list-update', { detail: { list: data.list } }));
                     break;

--- a/server.js
+++ b/server.js
@@ -530,6 +530,10 @@ wss.on('connection', (ws) => {
                 }
                 break;
 
+            case 'wiki-get-list':
+                ws.send(JSON.stringify({ type: 'wiki-page-list', publicPages: publicWikiPages, mjPages: mjWikiPages }));
+                break;
+
             case 'wiki-get-page':
                 try {
                     const { pageName, isMJPage } = data;

--- a/wiki.css
+++ b/wiki.css
@@ -1,87 +1,36 @@
 /*- Wiki Styles -*/
 
-.wiki-container {
+.wiki-controls {
     display: flex;
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-    gap: 10px;
-    background-color: #1e1e1e; /* Match main content background */
-}
-
-.wiki-sidebar {
-    flex-basis: 220px;
+    align-items: center;
+    gap: 5px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #3a3a3a;
     flex-shrink: 0;
-    padding: 10px;
-    border-right: 1px solid #333;
-    overflow-y: auto;
-    background-color: #2a2a2a; /* Match panel background */
-    border-radius: 8px;
 }
 
-.wiki-sidebar h3 {
-    margin-top: 0;
-    font-size: 1.2em;
-    border-bottom: 1px solid #444;
-    padding-bottom: 5px;
-    color: #ffffff;
-}
-
-.wiki-sidebar ul {
-    list-style: none;
-    padding: 0;
-    margin: 10px 0 0 0;
-}
-
-#wiki-mj-page-list {
-    max-height: 250px; /* Limit the height of the MJ list */
-    overflow-y: auto; /* Make it scrollable if it overflows */
-    padding-right: 5px; /* Add some padding so the scrollbar doesn't hug the text */
-    margin-bottom: 10px;
-}
-
-.wiki-sidebar ul li {
-    padding: 8px 10px;
-    cursor: pointer;
-    border-radius: 4px;
-    margin-bottom: 4px;
-    transition: background-color 0.2s;
-}
-
-.wiki-sidebar ul li:hover {
-    background-color: #3a3a3a;
-}
-
-.wiki-sidebar ul li.active {
-    background-color: #4CAF50; /* Use theme's accent color */
-    color: #ffffff;
-    font-weight: bold;
-}
-
-.new-page-btn {
-    width: 100%;
-    padding: 8px;
-    margin-bottom: 10px;
-    background-color: #2196F3; /* Blue, to distinguish from green active item */
-    color: white;
-    border: none;
+.wiki-controls select {
+    background-color: #3e3e3e;
+    color: #e0e0e0;
+    border: 1px solid #555;
     border-radius: 5px;
-    cursor: pointer;
-    transition: background-color 0.2s;
+    padding: 4px 8px;
+    font-size: 14px;
+    flex-grow: 1;
 }
 
-.new-page-btn:hover {
-    background-color: #1e88e5; /* Darker blue on hover */
+.wiki-controls select:hover {
+    background-color: #4a4a4a;
 }
 
 .wiki-main {
     flex-grow: 1;
-    padding: 20px;
     overflow-y: auto;
     display: flex;
     flex-direction: column;
     background-color: #2a2a2a; /* Match panel background */
     border-radius: 8px;
+    padding: 10px;
 }
 
 #wiki-viewer {


### PR DESCRIPTION
This commit addresses two main user requests:
1.  A bug where the MJ's image control buttons were visible but not functional. This was fixed by refactoring the logic to have `script.js` attach the event listeners at the same time it makes the controls visible, ensuring correct timing and preventing race conditions.
2.  A feature request to redesign the wiki UI. The previous sidebar list has been replaced with a more consistent UI featuring a `<select>` dropdown for page navigation and '+' buttons for adding new pages. This required significant changes to the HTML, a complete rewrite of `wiki.js` to manage the new components, and updated CSS in `wiki.css` to style the new layout.