### PR TITLE
Fix: Enable markdown table rendering in wiki

### DIFF
--- a/wiki.js
+++ b/wiki.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let easyMDE;
     let currentPage = null;
     let isMJ = window.isMJ || false;
-    const markdownConverter = new showdown.Converter();
+    const markdownConverter = new showdown.Converter({ tables: true });
     let isNewPageMJ = false;
 
     // --- WebSocket Communication ---


### PR DESCRIPTION
The showdown.js markdown converter did not have the `tables` option enabled, which caused markdown tables not to be rendered in the wiki.

This change enables the `tables` option in the `showdown.Converter` constructor in `wiki.js`.