### PR TITLE
feat: Remove 'Cyberpunk' sheet reference from localStorage

### DIFF
--- a/sheets.js
+++ b/sheets.js
@@ -23,7 +23,18 @@ document.addEventListener('DOMContentLoaded', () => {
     function loadSheets() {
         const storedSheets = localStorage.getItem(storageKey);
         if (storedSheets) {
-            sheets = JSON.parse(storedSheets);
+            let loadedSheets = JSON.parse(storedSheets);
+
+            // One-time migration: remove "Cyberpunk" sheets if they exist
+            const initialCount = loadedSheets.length;
+            loadedSheets = loadedSheets.filter(sheet => sheet.name !== 'Cyberpunk');
+
+            // If changes were made, save them back
+            if (loadedSheets.length < initialCount) {
+                localStorage.setItem(storageKey, JSON.stringify(loadedSheets));
+            }
+
+            sheets = loadedSheets;
             populateDropdown();
         }
     }


### PR DESCRIPTION
This change modifies the `sheets.js` file to automatically remove any character sheet named 'Cyberpunk' from the browser's localStorage upon page load.

This acts as a one-time data migration to address the user's request to delete the existing 'Cyberpunk' reference, which was not hardcoded in the application but stored as user data.